### PR TITLE
Add Domain Size Selector to Main Menu

### DIFF
--- a/Invoke-BadBlood.ps1
+++ b/Invoke-BadBlood.ps1
@@ -41,7 +41,49 @@ write-host "This is not intended for commercial use"
 Write-Host  'Press any key to continue...';
 write-host "`n"
 $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown');
+
+Write-Host  'Please select the SIZE of the domain that you want to create.';
+Write-Host  'S - SMALL';
+Write-Host  'M - MEDIUM'
+Write-Host  'L - LARGE';
+Write-Host  'X - X-LARGE';
+
+$choices = [Management.Automation.Host.ChoiceDescription[]] @(
+  New-Object Management.Automation.Host.ChoiceDescription("&S","SMALL: 10 to 100 users, 5 to 15 groups, 10 to 30 computers.")
+  New-Object Management.Automation.Host.ChoiceDescription("&M","MEDIUM: 100 to 1000 users, 15 to 100 groups, 10 to 30 computers.")
+  New-Object Management.Automation.Host.ChoiceDescription("&L","LARGE: 1000 to 5000 users, 100 to 500 groups, 50 to 150 computers.")
+  New-Object Management.Automation.Host.ChoiceDescription("&X","X-LARGE: 5000 to 5000 users, 500 to 750 groups, 150 to 400 computers.")
+)
+$domainsize = $Host.UI.PromptForChoice("Please select a size","`n",$choices,2)
+
+if ($domainsize -ieq "0") {
+    $userSize = 10..100|Get-Random ;
+    $groupSize = 5..15|Get-Random ;
+    $compNum = 10..30|Get-Random
+   }
+
+if($domainsize -ieq "1")
+   {$userSize = 100..1000|Get-Random;
+   $groupSize = 15..100|Get-Random;
+   $compNum = 30..150|Get-Random;
+   }
+
+if($domainsize -ieq "2")
+{$userSize = 1000..5000|Get-Random;
+$groupSize = 100..500|Get-Random;
+$compNum = 50..150|Get-Random
+}
+
+ if($domainsize -ieq "3")
+{$userSize = 5000..10000|Get-Random;
+$groupSize = 500..750|Get-Random;
+$compNum = 150..400| Get-Random
+}
+
 write-host "`n"
+write-host "Domain size selected! `n Users: $userSize `n Groups: $groupSize `n Computers: $compNum"
+write-host "`n"
+
 $badblood = Read-Host -Prompt "Type `'badblood`' to deploy some randomness into a domain"
 $badblood.tolower()
 if($badblood -ne 'badblood'){exit}
@@ -58,7 +100,11 @@ if($badblood -eq 'badblood'){
     $I++
     $ousAll = Get-adorganizationalunit -filter *
     write-host "Creating Users on Domain" -ForegroundColor Green
-    $NumOfUsers = 1000..5000|Get-random #this number is the random number of users to create on a domain.  Todo: Make process createusers.ps1 in a parallel loop
+    
+    
+    $NumOfUsers = $userSize|Get-random #this number is the random number of users to create on a domain.  Todo: Make process createusers.ps1 in a parallel loop
+   
+   
     $X=1
     Write-Progress -Activity "Random Stuff into A domain - Creating Users" -Status "Progress:" -PercentComplete ($i/$totalscripts*100)
     $I++
@@ -72,7 +118,11 @@ if($badblood -eq 'badblood'){
     $AllUsers = Get-aduser -Filter *
     
     write-host "Creating Groups on Domain" -ForegroundColor Green
-    $NumOfGroups = 100..500|Get-random 
+    
+    
+    $NumOfGroups = $groupSize|Get-random 
+    
+    
     $X=1
     Write-Progress -Activity "Random Stuff into A domain - Creating $NumOfGroups Groups" -Status "Progress:" -PercentComplete ($i/$totalscripts*100)
     $I++
@@ -87,7 +137,11 @@ if($badblood -eq 'badblood'){
     $Grouplist = Get-ADGroup -Filter { GroupCategory -eq "Security" -and GroupScope -eq "Global"  } -Properties isCriticalSystemObject
     $LocalGroupList =  Get-ADGroup -Filter { GroupScope -eq "domainlocal"  } -Properties isCriticalSystemObject
     write-host "Creating Computers on Domain" -ForegroundColor Green
-    $NumOfComps = 50..150|Get-random 
+    
+    
+    $NumOfComps = $compNum|Get-random 
+    
+    
     $X=1
     Write-Progress -Activity "Random Stuff into A domain - Creating Computers" -Status "Progress:" -PercentComplete ($i/$totalscripts*100)
     .($basescriptPath + '\AD_Computers_Create\CreateComputers.ps1')

--- a/Invoke-BadBlood.ps1
+++ b/Invoke-BadBlood.ps1
@@ -10,6 +10,7 @@
     .NOTES
        Written by David Rowe, Blog secframe.com/blog
        Twitter : @davidprowe
+       Domain Size Selector by HuskyHacks
        I take no responsibility for any issues caused by this script.  I am not responsible if this gets run in a production domain.  
     .FUNCTIONALITY
        Adds a ton of stuff into a domain.  Adds Users, Groups, OUs, Computers, and a vast amount of ACLs in a domain.
@@ -90,8 +91,6 @@ if($badblood -ne 'badblood'){exit}
 if($badblood -eq 'badblood'){
    $Domain = Get-addomain
     Write-Progress -Activity "Random Stuff into A domain" -Status "Progress:" -PercentComplete ($i/$totalscripts*100)
-
-
     .($basescriptPath + '\AD_LAPS_Install\InstallLAPSSchema.ps1')
     Write-Progress -Activity "Random Stuff into A domain: Install LAPS" -Status "Progress:" -PercentComplete ($i/$totalscripts*100)
     $I++
@@ -100,11 +99,7 @@ if($badblood -eq 'badblood'){
     $I++
     $ousAll = Get-adorganizationalunit -filter *
     write-host "Creating Users on Domain" -ForegroundColor Green
-    
-    
-    $NumOfUsers = $userSize|Get-random #this number is the random number of users to create on a domain.  Todo: Make process createusers.ps1 in a parallel loop
-   
-   
+    $NumOfUsers = $userSize #this number is the random number of users to create on a domain.  Todo: Make process createusers.ps1 in a parallel loop
     $X=1
     Write-Progress -Activity "Random Stuff into A domain - Creating Users" -Status "Progress:" -PercentComplete ($i/$totalscripts*100)
     $I++
@@ -116,13 +111,8 @@ if($badblood -eq 'badblood'){
     $x++
     }while($x -lt $NumOfUsers)
     $AllUsers = Get-aduser -Filter *
-    
     write-host "Creating Groups on Domain" -ForegroundColor Green
-    
-    
-    $NumOfGroups = $groupSize|Get-random 
-    
-    
+    $NumOfGroups = $groupSize
     $X=1
     Write-Progress -Activity "Random Stuff into A domain - Creating $NumOfGroups Groups" -Status "Progress:" -PercentComplete ($i/$totalscripts*100)
     $I++
@@ -131,17 +121,12 @@ if($badblood -eq 'badblood'){
     do{
         Creategroup
         Write-Progress -Activity "Random Stuff into A domain - Creating $NumOfGroups Groups" -Status "Progress:" -PercentComplete ($x/$NumOfGroups*100)
-    
     $x++
     }while($x -lt $NumOfGroups)
     $Grouplist = Get-ADGroup -Filter { GroupCategory -eq "Security" -and GroupScope -eq "Global"  } -Properties isCriticalSystemObject
     $LocalGroupList =  Get-ADGroup -Filter { GroupScope -eq "domainlocal"  } -Properties isCriticalSystemObject
     write-host "Creating Computers on Domain" -ForegroundColor Green
-    
-    
-    $NumOfComps = $compNum|Get-random 
-    
-    
+    $NumOfComps = $compNum
     $X=1
     Write-Progress -Activity "Random Stuff into A domain - Creating Computers" -Status "Progress:" -PercentComplete ($i/$totalscripts*100)
     .($basescriptPath + '\AD_Computers_Create\CreateComputers.ps1')


### PR DESCRIPTION
Hi!

I noticed that you had a note in usage that you could change the number of hosts by editing the script. I wanted to make it a bit easier for people to fill a domain with a number of users, groups, and computers that could suit their needs as a student/researcher. So I put in a "t-shirt' size selector that will fill the domain based on four selections:

![image](https://user-images.githubusercontent.com/57866415/99477499-9e82da00-2920-11eb-922f-714087c01e3a.png)

The default selection (LARGE) is the same stats as the original script. Now, the user has the ability to tailor the script to their research needs with SMALL, MEDIUM, and X-LARGE domains as well!

All remaining functionality of the script remains the same.

### Domain Size Selections
#### Small

![image](https://user-images.githubusercontent.com/57866415/99477802-400a2b80-2921-11eb-9ca3-eed5090a50d3.png)

#### Medium

![image](https://user-images.githubusercontent.com/57866415/99477843-5a440980-2921-11eb-9ffa-17bbf3d44156.png)


#### Large (Default)

![image](https://user-images.githubusercontent.com/57866415/99477680-00dbda80-2921-11eb-96b1-bbb8cc6b345b.png)

#### X-Large 

![image](https://user-images.githubusercontent.com/57866415/99477751-2668e400-2921-11eb-8422-38a91085bde3.png)

#### Random and No Input (Defaults to Large)

![image](https://user-images.githubusercontent.com/57866415/99477890-75167e00-2921-11eb-90e7-b7e5c9fb2a1b.png)
