### PR TITLE
Add does not require preauth randomly

### DIFF
--- a/AD_Users_Create/CreateUsers.ps1
+++ b/AD_Users_Create/CreateUsers.ps1
@@ -266,6 +266,15 @@
         
     
     $pwd = ''
+
+    #==============================
+    # Set Does Not Require Pre-Auth for ASREP
+    #==============================
+    
+    $setASREP = 1..1000|get-random
+    if($setASREP -lt 20){
+	Get-ADuser $name | Set-ADAccountControl -DoesNotRequirePreAuth:$true
+    }
     
     #===============================
     #SET ATTRIBUTES - no additional attributes set at this time besides UPN


### PR DESCRIPTION
Randomly assignes does not require preauth so that users can be as-rep roasted. 